### PR TITLE
Update development environment on docker to fix errors depends on m3 Mac

### DIFF
--- a/.service/blog/.conf.d/my.cnf
+++ b/.service/blog/.conf.d/my.cnf
@@ -1,4 +1,5 @@
 [mysqld]
 character-set-server=utf8mb4
+innodb_use_native_aio=0
 [client]
 default-character-set=utf8mb4

--- a/.service/blog/Dockerfile.mysql
+++ b/.service/blog/Dockerfile.mysql
@@ -1,4 +1,4 @@
-FROM mysql:8.0.32-debian
+FROM mysql:8.0.35-debian
 
 RUN apt-get update && apt-get install -y locales \
   && sed -i -e 's/# \(ja_JP.UTF-8\)/\1/' /etc/locale.gen \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       dockerfile: Dockerfile.mysql
       context: ./.service/blog/
+    platform: linux/x86_64
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: yes
       LC_ALL: ja_JP.UTF-8


### PR DESCRIPTION
M3 Mac上で開発環境が動かなくなってしまったため、対応。

ARCHのエミュレート
https://github.com/suzuito/sandbox2-go/pull/48/commits/8ae5060e74dddf4b947a593edbe6a9c34d96a63f

innodb_use_native_aio=0
https://github.com/suzuito/sandbox2-go/pull/48/commits/6d194addcd95ae14a2b010d729076a50500a771e

これにより開発環境のパフォーマンスが悪化する。
M3 Macに対応するDocker imageがリリースされたら、ここで追加した修正を戻すこと。

OS/ARCH=linux/arm64/v8
mysqlの3.0.x-debian
イメージがリリースされたら戻す。